### PR TITLE
Allow newer pandas

### DIFF
--- a/gcamreader/querymi.py
+++ b/gcamreader/querymi.py
@@ -40,7 +40,7 @@ class Query:
             xmlq = xmlin
 
         query = xmlq.find('./*[@title]')
-        self.querystr = ET.tounicode(query)
+        self.querystr = ET.tostring(query, encoding='unicode')
 
         regions = xmlq.findall('region')
         if len(regions) == 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests~=2.20.0
 pandas~=1.2.4
-lxml>=4.3.6
+lxml>=4.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests~=2.20.0
-pandas~=1.2.4
+pandas>=1.2.4
 lxml>=4.6.3

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author_email="robert.link@pnnl.gov",
     install_requires=[
         "requests~=2.20.0",
-        "pandas~=1.2.4",
+        "pandas>=1.2.4",
         "lxml>=4.6.3"
     ],
     include_package_data=True,


### PR DESCRIPTION
Change version of lxml in requirements.txt to match version in setup.py
Allow pandas>=1.2.4 rather than just pandas~=1.2.4 for compatibility with packages requiring more recent versions