### PR TITLE
Add Main_queries.xml compatible xml selector for queries.

### DIFF
--- a/gcamreader/querymi.py
+++ b/gcamreader/querymi.py
@@ -35,14 +35,13 @@ class Query:
 
         if xmlin.__class__ is str:
             parser = ET.XMLParser(strip_cdata=False)
-            xmlq = ET.XML(xmlin, parser)
+            query = ET.XML(xmlin, parser)
         else:
-            xmlq = xmlin
+            query = xmlin
 
-        query = xmlq.find('./*[@title]')
         self.querystr = ET.tostring(query, encoding='unicode')
 
-        regions = xmlq.findall('region')
+        regions = query.findall("region")
         if len(regions) == 0:
             self.regions = None
         else:
@@ -57,7 +56,7 @@ def parse_batch_query(filename):
     parser = ET.XMLParser(strip_cdata=False)
     root = ET.parse(filename, parser)
 
-    queries = root.findall('aQuery')
+    queries = root.xpath("//*[@title]")
 
     return [Query(q) for q in queries]
 


### PR DESCRIPTION
I tried running gcamreader as is with the queries defined in Main_queries.xml (from gcam-core) and it did not recognize the structure. This is because the gcamreader package assumes queries are contained within an `<aQuery>` tag. All the queries in Main_queries.xml are contained in tags like `<supplyDemandQuery>` so the `root.findall('aQuery')` does not select for them.

Replacing this with an xpath selector for the title property makes this package compatible with Main_queries.xml out of the box.