### PR TITLE
Add query multiprocessing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "1.3.1"
+VERSION = "1.4.0"
 
 
 def readme():


### PR DESCRIPTION
This adds multiprocessing to the cli, using the [mutliprocessing python stdlib module](https://docs.python.org/3/library/multiprocessing.htm), so many queries can be run simultaneously.

Since this package calls out to a subprocess already for each query, dispatching in a multiprocessing pool saves a lot of time when running a lot of queries. This is possible because none of the child processes share any mutable state - the .basex files are simultaneously read from, but each subprocess opens them on their own, and therefore do not share file descriptors/handles.

This pull request is predicated on #32 getting merged.