### PR TITLE
GH Actions click install order

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
             sudo apt-get install -y libxml2-dev
             sudo snap install libxslt
             python -m pip install --upgrade pip
+            pip install click
             python setup.py install
 
         - name: Test and generate coverage report on Linux

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 requests~=2.20.0
 pandas>=1.2.4
 lxml>=4.6.3
+click>=8.1
+click-default-group-wheel>=1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests~=2.20.0
 pandas>=1.2.4
 lxml>=4.6.3
 click>=8.1
-click-default-group-wheel>=1.2
+click-default-group>=1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests~=2.20.0
 pandas>=1.2.4
 lxml>=4.6.3
-click>=8.1
-click-default-group>=1.2
+click==8.1.6
+click-default-group==1.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests~=2.20.0
 pandas>=1.2.4
 lxml>=4.6.3
-click==8.1.6
-click-default-group==1.2.3
+click
+click-default-group-wheel

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
         "requests~=2.20.0",
         "pandas>=1.2.4",
         "lxml>=4.6.3"
-        "click",
-        "click-default-group-wheel",
+        "click>=8.1",
+        "click-default-group-wheel>=1.2",
     ],
     entry_points="""
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "pandas>=1.2.4",
         "lxml>=4.6.3"
         "click>=8.1.7",
-        "click-default-group-wheel>=1.2.2",
+        "click-default-group>=1.2.2",
     ],
     entry_points="""
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
         "requests~=2.20.0",
         "pandas>=1.2.4",
         "lxml>=4.6.3"
-        "click>=8.1.6",
-        "click-default-group>=1.2.3",
+        "click",
+        "click-default-group-wheel",
     ],
     entry_points="""
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
         "requests~=2.20.0",
         "pandas>=1.2.4",
         "lxml>=4.6.3"
-        "click>=8.1.7",
-        "click-default-group>=1.2.2",
+        "click>=8.1.6",
+        "click-default-group>=1.2.3",
     ],
     entry_points="""
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 setup(
     name="gcamreader",
     version=VERSION,
-    python_requires=">=3.6",
+    python_requires=">=3.9",
     packages=find_packages(),
     description="Tools for importing GCAM output data",
     long_description=readme(),
@@ -23,8 +23,8 @@ setup(
         "requests~=2.20.0",
         "pandas>=1.2.4",
         "lxml>=4.6.3"
-        "click>=8.1",
-        "click-default-group-wheel>=1.2",
+        "click>=8.1.7",
+        "click-default-group-wheel>=1.2.2",
     ],
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
There is a bug in the way `click` and `click-default-group-wheel` interact in the actions dependency reconciliation.  Preinstalling `click` fixed the issue.